### PR TITLE
Update Malwarebytes-Premium-Reset.bat

### DIFF
--- a/Malwarebytes-Premium-Reset.bat
+++ b/Malwarebytes-Premium-Reset.bat
@@ -1,14 +1,19 @@
 :: ==================================================
-::  Malwarebytes-Premium-Reset v12.6
+::  Malwarebytes-Premium-Reset v12.7
 :: ==================================================
 ::  Dev  - Scut1ny
 ::  Help - AmmarSAA & firebirdjsb
 ::  Link - https://github.com/Scrut1ny/Malwarebytes-Premium-Reset
+::
+::  Note: using this will wipe all your Malwarebytes settings
+::
+::
+::  changelog for v12.7: removed file backup and restore functions from 12.6 as they did not work as intended due to limitations
 :: ==================================================
 
 
 @echo off
-title Malwarebytes-Premium-Reset ^| v12.6
+title Malwarebytes-Premium-Reset ^| v12.7
 
 :: Check for administrator privileges
 fltmc >nul 2>&1 || (
@@ -29,20 +34,6 @@ echo   [+] Killing certain Mbam Processes!
 start "" "%ProgramFiles%\Malwarebytes\Anti-Malware\malwarebytes_assistant.exe" --stopservice
 
 echo Processes have been Killed. && timeout /t 5 >nul
-cls && echo( && echo   [94mMalwarebytes[0m: [33mPremium[0m - [[31mBYPASS[0m]
-echo   --------------------------------&& echo(
-
-
-REM Backup specified files to a new folder on the user's desktop
-set "backupFolder=%USERPROFILE%\Desktop\Malwarebytes_Backup"
-if not exist "%backupFolder%" (
-    mkdir "%backupFolder%"
-)
-echo Backing Up Certain Mbam Files && timeout /t 5 >nul
-REM Copy files to backup folder (overwrite if they exist)
-copy /Y "C:\ProgramData\Malwarebytes\MBAMService\config\ArwControllerConfig.json" "%backupFolder%" >nul
-copy /Y "C:\ProgramData\Malwarebytes\MBAMService\config\ScanConfig.json" "%backupFolder%" >nul
-copy /Y "C:\ProgramData\Malwarebytes\MBAMService\config\RtpConfig.json" "%backupFolder%" >nul
 cls && echo( && echo   [94mMalwarebytes[0m: [33mPremium[0m - [[31mBYPASS[0m]
 echo   --------------------------------&& echo(
 
@@ -72,44 +63,9 @@ echo   [+] Task executed. && timeout /t 5 >nul
 
 cls && echo( && echo   [94mMalwarebytes[0m: [33mPremium[0m - [[31mBYPASS[0m]
 echo   --------------------------------&& echo(
-
-REM Restoring backed-up files to Malwarebytes folder && timeout /t 5 >nul
-echo   [+] Restoring backed-up files to Malwarebytes folder... && timeout /t 5 >nul
-
-copy /Y "%USERPROFILE%\Desktop\Malwarebytes_Backup\ArwControllerConfig.json" "C:\ProgramData\Malwarebytes\MBAMService\config\" >nul
-IF NOT ERRORLEVEL 0 (
-    echo   [!] Failed to restore ArwControllerConfig.json && timeout /t 5 >nul
-    REM Handle error, check permissions, or file locking issues
-) ELSE (
-    echo   [+] ArwControllerConfig.json restored successfully. && timeout /t 5 >nul
-)
-
-copy /Y "%USERPROFILE%\Desktop\Malwarebytes_Backup\ScanConfig.json" "C:\ProgramData\Malwarebytes\MBAMService\config\" >nul
-IF NOT ERRORLEVEL 0 (
-    echo   [!] Failed to restore ScanConfig.json && timeout /t 5 >nul
-    REM Handle error, check permissions, or file locking issues
-) ELSE (
-    echo   [+] ScanConfig.json restored successfully. && timeout /t 5 >nul
-)
-
-copy /Y "%USERPROFILE%\Desktop\Malwarebytes_Backup\RtpConfig.json" "C:\ProgramData\Malwarebytes\MBAMService\config\" >nul
-IF NOT ERRORLEVEL 0 (
-    echo   [!] Failed to restore RtpConfig.json && timeout /t 5 >nul
-    REM Handle error, check permissions, or file locking issues
-) ELSE (
-    echo   [+] RtpConfig.json restored successfully. && timeout /t 5 >nul
-)
-cls && echo( && echo   [94mMalwarebytes[0m: [33mPremium[0m - [[31mBYPASS[0m]
-echo   --------------------------------&& echo(
 echo   [+] Restarting Mbam Processes... && timeout /t 3 >nul
 start "" "%ProgramFiles%\Malwarebytes\Anti-Malware\mbam.exe" >nul 2>&1 && timeout /t 5  >nul
 
-RD /S /Q "%USERPROFILE%\Desktop\Malwarebytes_Backup" >nul 2>&1 && timeout /t 5 >nul
-IF ERRORLEVEL 1 (
-    echo   [!] Failed to delete backup folder.
-    REM Handle error or permissions issue if necessary
-) ELSE (
-    echo   [+] Backup folder deleted successfully.
-)
+
 echo   [+] Done, thank you for use this trial resetter.
 echo(&&pause


### PR DESCRIPTION
removes the functions added in 12.6 for backup and file copy and transfer also idk what changed in the last 3 commits but this script runs every-time no extra keypresses when exported as exe or anything so this should clear up both of the errors and close them out  as well